### PR TITLE
remove blank space on newlines

### DIFF
--- a/src/Docblock.php
+++ b/src/Docblock.php
@@ -390,7 +390,7 @@ class Docblock {
 	protected function writeLines($lines, $newline = false) {
 		$docblock = '';
 		if ($newline) {
-			$docblock .= " * \n";
+			$docblock .= " *\n";
 		}
 
 		foreach ($lines as $line) {

--- a/tests/DocblockTest.php
+++ b/tests/DocblockTest.php
@@ -35,7 +35,7 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
 	public function testSimpleReadWrite() {
 		$expected = '/**
  * Short Description.
- * 
+ *
  * Long Description.
  */';
 		$docblock = new Docblock($expected);
@@ -96,12 +96,12 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
 	public function testMultilLongLineDescription() {
 		$expected = '/**
  * Short Description.
- * 
+ *
  * Long Description, which is very long and takes ages to reach the very last of the current line
  * before it brakes onto the next line
  * 
  * sdfasdf @tag
- * 
+ *
  * @tag2 wurst multi-
  *     linee
  */';
@@ -112,7 +112,7 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
 	public function testFromReflection() {
 		$expected = '/**
  * Short Description.
- * 
+ *
  * @author gossi
  */';
 		$reflection = new \ReflectionClass('\\gossi\\docblock\\tests\\fixtures\\ReflectionTestClass');


### PR DESCRIPTION
PHP-CS-Fixer & others are complaining about empty spaces in newline doc-comments. 
this PR removes it
