### PR TITLE
Move forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .buildpath
 composer.lock
 composer.phar
+.php.cs.cache
+.phpunit.result.cache
+sami.phar
 vendor/
 api/
 cache/

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+$config = new phootwork\fixer\Config();
+$config->getFinder()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests')
+;
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: php
 
-dist: trusty
-
 php:
-  - 5.6
-  - 7
-  - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
+  - 7.4
   
 install:
   - composer install
   
-script: 
-  - vendor/bin/phpunit --coverage-clover=coverage.clover
+script:
+  - composer cs
+  - composer coverage:clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - php ocular.phar code-coverage:upload --format=php-clover clover.xml

--- a/composer.json
+++ b/composer.json
@@ -18,24 +18,47 @@
 	},
 	"autoload" : {
 		"psr-4" : {
-			"gossi\\docblock\\" : "src"
+			"gossi\\docblock\\" : "src/"
 		}
 	},
 	"autoload-dev" : {
 		"psr-4" : {
-			"gossi\\docblock\\tests\\" : "tests"
+			"gossi\\docblock\\tests\\" : "tests/",
+			"gossi\\docblock\\scripts\\": "scripts/"
 		}
 	},
 	"require" : {
-		"php" : ">=5.6",
-		"phootwork/collection" : "^1.5"
+		"php" : ">=7.2",
+		"phootwork/lang": "2.0",
+		"phootwork/collection" : "2.0"
 	},
 	"require-dev" : {
-		"phpunit/phpunit" : "^5.7",
-		"sami/sami" : "^4|^3"
+		"phpunit/phpunit" : "^8.0",
+		"phootwork/php-cs-fixer-config": "^0.2.2",
+		"vimeo/psalm": "^3.7"
 	},
-	"scripts" : {
-		"test" : "phpunit",
-		"api" : "sami.php update sami.php"
+	"scripts": {
+		"analytics": "psalm",
+		"check": [
+			"@test",
+			"@analytics",
+			"@cs-fix"
+		],
+		"coverage:html": "@test --coverage-html coverage/",
+		"coverage:clover": "@test --coverage-clover clover.xml",
+		"cs": "php-cs-fixer fix -v --diff --dry-run",
+		"cs-fix": "php-cs-fixer fix -v --diff",
+		"test": "phpunit",
+		"api": "gossi\\docblock\\scripts\\Api::generateApi"
+	},
+	"scripts-descriptions": {
+		"analytics": "Run static analysis tool",
+		"check": "Perform all tests and analysis, required before submitting a pull request",
+		"coverage:html": "Create a code coverage report in html format, into the `coverage/` directory",
+		"coverage:clover": "Create a code coverage report in xml format, into clover.xml file",
+		"cs": "Run code style analysis, without fixing errors",
+		"cs-fix": "Run code style analysis and fix errors",
+		"test": "Run all tests",
+		"api": "Download `sami.phar` archive and generate the api documentation for this library"
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>
@@ -18,16 +17,9 @@
     </testsuites>
     
     <filter>
-    	<blacklist>
-    		<directory>tests/</directory>
-    		<directory>vendor/</directory>
-    	</blacklist>
     	<whitelist processUncoveredFilesFromWhitelist="true">
     		<directory suffix=".php">src/</directory>
     	</whitelist>
     </filter>
-    
-    <logging>
-		<log type="coverage-html" target="coverage"/>
-	</logging>
+
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/sami.php
+++ b/sami.php
@@ -1,5 +1,4 @@
 <?php
-require_once __DIR__ . '/vendor/autoload.php';
 
 use Sami\Sami;
 use Symfony\Component\Finder\Finder;

--- a/scripts/Api.php
+++ b/scripts/Api.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace gossi\docblock\scripts;
+
+/**
+ * Class to generate api. Useful for composer script.
+ */
+class Api {
+	public static function generateApi(): void {
+		if (!file_exists('sami.phar')) {
+			self::downloadSami();
+		}
+
+		if (strpos(phpversion(), '7.4') !== false) {
+			die("
+Sami cannot run on PHP 7.4 due to some deprecations.
+If you have installed some other php versions, you could manually run it:
+
+ php7.3 sami.phar update sami.php
+
+"
+			);
+		}
+
+		exec("php sami.phar update sami.php");
+	}
+
+	private static function downloadSami(): void {
+		if (!extension_loaded('curl')) {
+			die("
+You should enable `curl` extensions in your php.ini, to download sami.
+Alternatively, you can download it manually from http://get.sensiolabs.org/sami.phar
+");
+		}
+
+		$fp = fopen('./sami.phar', 'wb');
+
+		echo "Donload sami...";
+		$ch = curl_init('http://get.sensiolabs.org/sami.phar');
+		curl_setopt($ch, CURLOPT_FILE, $fp);
+		curl_setopt($ch, CURLOPT_HEADER, 0);
+		curl_exec($ch);
+		curl_close($ch);
+		echo "done!\n";
+
+		fclose($fp);
+	}
+}

--- a/src/Docblock.php
+++ b/src/Docblock.php
@@ -1,85 +1,103 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace gossi\docblock;
 
-use gossi\docblock\tags\TagFactory;
 use gossi\docblock\tags\AbstractTag;
+use gossi\docblock\tags\TagFactory;
+use InvalidArgumentException;
+use LogicException;
 use phootwork\collection\ArrayList;
 use phootwork\collection\Map;
+use phootwork\lang\Comparator;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionProperty;
 
 class Docblock {
-	
+
+	/** @var string */
 	protected $shortDescription;
+
+	/** @var string */
 	protected $longDescription;
+
+	/** @var ArrayList */
 	protected $tags;
+
+	/** @var null|Comparator */
 	protected $comparator = null;
-	
+
 	const REGEX_TAGNAME = '[\w\-\_\\\\]+';
-	
+
 	/**
 	 * Static docblock factory
 	 * 
-	 * @param string \Reflector|$docblock
+	 * @param ReflectionFunctionAbstract|ReflectionClass|ReflectionProperty|string $docblock a docblock to parse
+	 *
 	 * @return $this
 	 */
-	public static function create($docblock = null) {
+	public static function create($docblock = ''): self {
 		return new static($docblock);
 	}
-	
+
 	/**
 	 * Creates a new docblock instance and parses the initial string or reflector object if given
 	 * 
-	 * @param \ReflectionFunctionAbstract|\ReflectionClass|\ReflectionProperty|string a docblock to parse
+	 * @param ReflectionFunctionAbstract|ReflectionClass|ReflectionProperty|string $docblock a docblock to parse
 	 */
-	public function __construct($docblock = null) {
+	public function __construct($docblock = '') {
 		$this->tags = new ArrayList();
 		$this->parse($docblock);
 	}
-	
+
 	/**
 	 * @see https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/phpDocumentor/Reflection/DocBlock.php Original Method
-	 * @param \ReflectionFunctionAbstract|\ReflectionClass|\ReflectionProperty|string $docblock
-	 * @throws \InvalidArgumentException if there is no getDocCommect() method available
+	 *
+	 * @param ReflectionFunctionAbstract|ReflectionClass|ReflectionProperty|string $docblock
+	 *
+	 * @throws InvalidArgumentException if there is no getDocCommect() method available
 	 */
-	protected function parse($docblock) {
+	protected function parse($docblock): void {
 		if (is_object($docblock)) {
 			if (!method_exists($docblock, 'getDocComment')) {
-				throw new \InvalidArgumentException('Invalid object passed; the given ' .
+				throw new InvalidArgumentException('Invalid object passed; the given ' .
 						'reflector must support the getDocComment method');
 			}
-		
+
 			$docblock = $docblock->getDocComment();
 		}
-		
+
 		$docblock = $this->cleanInput($docblock);
-		
-		list($short, $long, $tags) = $this->splitDocBlock($docblock);
+
+		[$short, $long, $tags] = $this->splitDocBlock($docblock);
 		$this->shortDescription = $short;
 		$this->longDescription = $long;
 		$this->parseTags($tags);
 	}
-	
+
 	/**
 	 * Strips the asterisks from the DocBlock comment.
 	 * 
 	 * @see https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/phpDocumentor/Reflection/DocBlock.php Original Method
+	 *
 	 * @param string $comment String containing the comment text.
+	 *
 	 * @return string
 	 */
-	protected function cleanInput($comment) {
-		$comment = trim(preg_replace('#[ \t]*(?:\/\*\*|\*\/|\*)?[ \t]{0,1}(.*)?#u',	'$1', $comment));
-	
+	protected function cleanInput(string $comment): string {
+		$comment = trim(preg_replace('#[ \t]*(?:\/\*\*|\*\/|\*)?[ \t]{0,1}(.*)?#u', '$1', $comment));
+
 		// reg ex above is not able to remove */ from a single line docblock
 		if (substr($comment, -2) == '*/') {
 			$comment = trim(substr($comment, 0, -2));
 		}
-	
+
 		// normalize strings
-		$comment = str_replace(array("\r\n", "\r"), "\n", $comment);
-	
+		$comment = str_replace(["\r\n", "\r"], "\n", $comment);
+
 		return $comment;
 	}
-	
+
 	/**
 	 * Splits the Docblock into a short description, long description and
 	 * block of tags.
@@ -94,16 +112,16 @@ class Docblock {
 	 * @return string[] containing the short-, long description and an element
 	 *     containing the tags.
 	 */
-	protected function splitDocBlock($comment) {
+	protected function splitDocBlock(string $comment): array {
 		$matches = [];
-		
+
 		if (strpos($comment, '@') === 0) {
-			$matches = array('', '', $comment);
+			$matches = ['', '', $comment];
 		} else {
 			// clears all extra horizontal whitespace from the line endings
 			// to prevent parsing issues
 			$comment = preg_replace('/\h*$/Sum', '', $comment);
-			
+
 			/*
 			 * Splits the docblock into a short description, long description and
 			 * tags section
@@ -148,25 +166,28 @@ class Docblock {
 			);
 			array_shift($matches);
 		}
-	
+
 		while (count($matches) < 3) {
 			$matches[] = '';
 		}
+
 		return $matches;
 	}
-	
+
 	/**
 	 * Parses the tags
 	 * 
 	 * @see https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/phpDocumentor/Reflection/DocBlock.php Original Method
+	 *
 	 * @param string $tags
-	 * @throws \LogicException
-	 * @throws \InvalidArgumentException
+	 *
+	 * @throws LogicException
+	 * @throws InvalidArgumentException
 	 */
-	protected function parseTags($tags) {
+	protected function parseTags(string $tags): void {
 		$tags = trim($tags);
 		if (!empty($tags)) {
-			
+
 			// sanitize lines
 			$result = [];
 			foreach (explode("\n", $tags) as $line) {
@@ -181,79 +202,85 @@ class Docblock {
 			if (count($result)) {
 				$this->tags->clear();
 				foreach ($result as $line) {
-					$this->tags->add($this->parseTag($line)); 
+					$this->tags->add($this->parseTag($line));
 				}
 			}
 		}
-		
-		
 	}
-	
+
 	/**
 	 * Checks whether the given line is a tag line (= starts with @) or not
 	 * 
 	 * @param string $line
-	 * @return boolean
+	 *
+	 * @return bool
 	 */
-	protected function isTagLine($line) {
+	protected function isTagLine(string $line): bool {
 		return isset($line[0]) && $line[0] == '@';
 	}
-	
+
 	/**
 	 * Parses an individual tag line
 	 * 
 	 * @param string $line
-	 * @throws \InvalidArgumentException
-	 * @return \gossi\docblock\tags\AbstractTag
+	 *
+	 * @throws InvalidArgumentException
+	 *
+	 * @return AbstractTag
 	 */
-	protected function parseTag($line) {
+	protected function parseTag(string $line): AbstractTag {
 		$matches = [];
 		if (!preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s*([^\s].*)|$)?/us', $line, $matches)) {
-			throw new \InvalidArgumentException('Invalid tag line detected: ' . $line);
+			throw new InvalidArgumentException('Invalid tag line detected: ' . $line);
 		}
-		
+
 		$tagName = $matches[1];
 		$content = isset($matches[2]) ? $matches[2] : '';
-		
+
 		return TagFactory::create($tagName, $content);
 	}
-	
+
 	/**
 	 * Returns the short description
 	 * 
 	 * @return string the short description
 	 */
-	public function getShortDescription() {
+	public function getShortDescription(): string {
 		return $this->shortDescription;
 	}
-	
+
 	/**
 	 * Sets the short description
 	 * 
 	 * @param string $description the new description     
+	 *
 	 * @return $this   	
 	 */
-	public function setShortDescription($description) {
+	public function setShortDescription(string $description = ''): self {
 		$this->shortDescription = $description;
+
 		return $this;
 	}
-	
+
 	/**
 	 * Returns the long description
 	 *
 	 * @return string the long description
 	 */
-	public function getLongDescription() {
+	public function getLongDescription(): string {
 		return $this->longDescription;
 	}
-	
+
 	/**
 	 * Sets the long description
 	 * 
-	 * @param string $description the new description        	
+	 * @param string $description the new description
+	 *
+	 * @return $this
 	 */
-	public function setLongDescription($description) {
+	public function setLongDescription(string $description = ''): self {
 		$this->longDescription = $description;
+
 		return $this;
 	}
 
@@ -261,10 +288,12 @@ class Docblock {
 	 * Adds a tag to this docblock
 	 * 
 	 * @param AbstractTag $tag
+	 *
 	 * @return $this
 	 */
-	public function appendTag(AbstractTag $tag) {
+	public function appendTag(AbstractTag $tag): self {
 		$this->tags->add($tag);
+
 		return $this;
 	}
 
@@ -273,8 +302,8 @@ class Docblock {
 	 *
 	 * @param string $tagName
 	 */
-	public function removeTags($tagName = null) {
-		$this->tags = $this->tags->filter(function ($tag) use ($tagName) {
+	public function removeTags(string $tagName = ''): void {
+		$this->tags = $this->tags->filter(function (AbstractTag $tag) use ($tagName): bool {
 			return $tagName !== $tag->getTagName();
 		});
 	}
@@ -283,22 +312,24 @@ class Docblock {
 	 * Checks whether a tag is present
 	 * 
 	 * @param string $tagName
-	 * @return boolean
+	 *
+	 * @return bool
 	 */
-	public function hasTag($tagName) {
-		return $this->tags->search($tagName, function (AbstractTag $tag, $query) {
+	public function hasTag(string $tagName): bool {
+		return $this->tags->search($tagName, function (AbstractTag $tag, string $query): bool {
 			return $tag->getTagName() == $query;
 		});
 	}
-	
+
 	/**
 	 * Gets tags (by tag name)
 	 * 
 	 * @param string $tagName
+	 *
 	 * @return ArrayList the tags
 	 */
-	public function getTags($tagName = null) {
-		return $this->tags->filter(function ($tag) use ($tagName) {
+	public function getTags(string $tagName = null): ArrayList {
+		return $this->tags->filter(function (AbstractTag $tag) use ($tagName): bool {
 			return $tagName === null || $tag->getTagName() == $tagName;
 		});
 	}
@@ -308,86 +339,87 @@ class Docblock {
 	 * 
 	 * @return ArrayList
 	 */
-	public function getSortedTags() {
+	public function getSortedTags(): ArrayList {
 		if ($this->comparator === null) {
-			$this->comparator = new TagNameComparator(); 
+			$this->comparator = new TagNameComparator();
 		}
 
 		// 1) group by tag name
 		$group = new Map();
-		foreach ($this->tags as $tag) {
+		foreach ($this->tags->toArray() as $tag) {
 			if (!$group->has($tag->getTagName())) {
 				$group->set($tag->getTagName(), new ArrayList());
 			}
-			
+
 			$group->get($tag->getTagName())->add($tag);
-		} 
-		
+		}
+
 		// 2) Sort the group by tag name
 		$group->sortKeys(new TagNameComparator());
-		
+
 		// 3) flatten the group
 		$sorted = new ArrayList();
-		foreach ($group->values() as $tags) {
-			$sorted->addAll($tags);
+		foreach ($group->values()->toArray() as $tags) {
+			$sorted->add(...$tags);
 		}
-		
+
 		return $sorted;
 	}
-	
+
 	/**
 	 * Returns true when there is no content in the docblock
 	 *  
-	 * @return boolean
+	 * @return bool
 	 */
-	public function isEmpty() {
-		return empty($this->shortDescription) 
-				&& empty($this->longDescription) 
+	public function isEmpty(): bool {
+		return empty($this->shortDescription)
+				&& empty($this->longDescription)
 				&& $this->tags->size() == 0;
 	}
-	
+
 	/**
 	 * Returns the string version of the docblock
 	 * 
 	 * @return string
 	 */
-	public function toString() {
+	public function toString(): string {
 		$docblock = "/**\n";
-		
+
 		// short description
 		$short = trim($this->shortDescription);
 		if (!empty($short)) {
 			$docblock .= $this->writeLines(explode("\n", $short));
 		}
-		
+
 		// short description
 		$long = trim($this->longDescription);
 		if (!empty($long)) {
 			$docblock .= $this->writeLines(explode("\n", $long), !empty($short));
 		}
-		
+
 		// tags
-		$tags = $this->getSortedTags()->map(function($tag) {
-			return $tag->toString();
+		$tags = $this->getSortedTags()->map(function (AbstractTag $tag): string {
+			return (string) $tag;
 		});
-		
+
 		if (!$tags->isEmpty()) {
 			$docblock .= $this->writeLines($tags->toArray(), !empty($short) || !empty($long));
 		}
 
 		$docblock .= ' */';
-		
+
 		return $docblock;
 	}
-	
+
 	/**
 	 * Writes multiple lines with ' * ' prefixed for docblock
 	 * 
 	 * @param string[] $lines the lines to be written
-	 * @param boolean $newline if a new line should be added before
+	 * @param bool $newline if a new line should be added before
+	 *
 	 * @return string the lines as string
 	 */
-	protected function writeLines($lines, $newline = false) {
+	protected function writeLines(array $lines, bool $newline = false): string {
 		$docblock = '';
 		if ($newline) {
 			$docblock .= " *\n";
@@ -403,10 +435,10 @@ class Docblock {
 				$docblock .= ' * ' . $line . "\n";
 			}
 		}
-		
+
 		return $docblock;
 	}
-	
+
 	/**
 	 * Magic toString() method
 	 * 
@@ -415,5 +447,4 @@ class Docblock {
 	public function __toString() {
 		return $this->toString();
 	}
-	
 }

--- a/src/TagNameComparator.php
+++ b/src/TagNameComparator.php
@@ -1,11 +1,11 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock;
 
 use phootwork\lang\Comparator;
 
 class TagNameComparator implements Comparator {
-	
-	public function compare($a, $b) {
+	public function compare($a, $b): int {
 		$order = ['see', 'author', 'property-read', 'property-write', 'property',
 				'method', 'deprecated', 'since', 'version', 'var', 'type', 'param',
 				'throws', 'return'];
@@ -13,19 +13,18 @@ class TagNameComparator implements Comparator {
 		if ($a == $b) {
 			return 0;
 		}
-		
+
 		if (!in_array($a, $order)) {
 			return -1;
 		}
-		
+
 		if (!in_array($b, $order)) {
 			return 1;
 		}
-		
+
 		$pos1 = array_search($a, $order);
 		$pos2 = array_search($b, $order);
-		
+
 		return $pos1 < $pos2 ? -1 : 1;
 	}
-
 }

--- a/src/tags/AbstractDescriptionTag.php
+++ b/src/tags/AbstractDescriptionTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -6,14 +7,15 @@ namespace gossi\docblock\tags;
  */
 abstract class AbstractDescriptionTag extends AbstractTag {
 
-	protected $description;
-	
+	/** @var string */
+	protected $description = '';
+
 	/**
 	 * Returns the description
 	 * 
 	 * @return string the description
 	 */
-	public function getDescription() {
+	public function getDescription(): string {
 		return $this->description;
 	}
 
@@ -21,12 +23,12 @@ abstract class AbstractDescriptionTag extends AbstractTag {
 	 * Sets the description
 	 * 
 	 * @param string $description the new description
+	 *
 	 * @return $this
 	 */
-	public function setDescription($description) {
+	public function setDescription(string $description): self {
 		$this->description = $description;
+
 		return $this;
 	}
-
-	
 }

--- a/src/tags/AbstractTag.php
+++ b/src/tags/AbstractTag.php
@@ -1,37 +1,38 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace gossi\docblock\tags;
 
 abstract class AbstractTag {
-	
+
+	/** @var string */
 	protected $tagName;
-	
+
 	/**
 	 * Creates a new tag instance
 	 *
 	 * @return $this
 	 */
-	public static function create($content = '') {
+	public static function create(string $content = '') {
 		return new static($content);
 	}
-	
+
 	/**
 	 * Creates a new tag instance
 	 *
 	 * @param string $tagName
 	 * @param string $content
 	 */
-	protected function __construct($tagName, $content = '') {
+	protected function __construct(string $tagName, string $content = '') {
 		$this->tagName = $tagName;
 		$this->parse($content);
 	}
-	
+
 	/**
 	 * Returns the tag name.
 	 *
 	 * @return string the tag name
 	 */
-	public function getTagName() {
+	public function getTagName(): string {
 		return $this->tagName;
 	}
 
@@ -40,10 +41,10 @@ abstract class AbstractTag {
 	 *
 	 * @param string $content
 	 */
-	abstract protected function parse($content);
-	
-	abstract protected function toString();
-	
+	abstract protected function parse(string $content): void;
+
+	abstract public function toString(): string;
+
 	/**
 	 * Magic toString() method
 	 *

--- a/src/tags/AbstractTypeTag.php
+++ b/src/tags/AbstractTypeTag.php
@@ -1,44 +1,49 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
  * Represents tags which are in the format
+ *
  *   @tag [Type] [Description] 
  */
 abstract class AbstractTypeTag extends AbstractDescriptionTag {
 
-	protected $type;
+	/** @var string */
+	protected $type = '';
 
-	protected function parse($content) {
+	protected function parse(string $content): void {
 		$parts = preg_split('/\s+/Su', $content, 2);
-		
+
 		$this->type = $parts[0];
 		$this->setDescription(isset($parts[1]) ? $parts[1] : '');
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		$type = $this->type ? $this->type . ' ' : '';
+
 		return trim(sprintf('@%s %s%s', $this->tagName, $type, $this->description));
 	}
-	
+
 	/**
 	 * Returns the type
 	 * 
 	 * @return string the type
 	 */
-	public function getType() {
+	public function getType(): string {
 		return $this->type;
 	}
-	
+
 	/**
 	 * Sets the type
 	 * 
 	 * @param string $type the new type
+	 *
 	 * @return $this
 	 */
-	public function setType($type) {
+	public function setType(string $type): self {
 		$this->type = $type;
+
 		return $this;
 	}
-	
 }

--- a/src/tags/AbstractVarTypeTag.php
+++ b/src/tags/AbstractVarTypeTag.php
@@ -1,51 +1,56 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
  * Represents tags which are in the format
+ *
  *   @tag [Type] [Variable] [Description]
  */
 abstract class AbstractVarTypeTag extends AbstractTypeTag {
 
-	protected $variable;
+	/** @var string */
+	protected $variable = '';
+
+	/** @var bool */
 	protected $isVariadic = false;
 
 	/**
 	 * @see https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/phpDocumentor/Reflection/DocBlock/Tag/ParamTag.php Original Method: setContent()
 	 * @see \gossi\docblock\tags\AbstractTypeTag::parse()
+	 *
+	 * @param string $content
 	 */
-	protected function parse($content) {
+	protected function parse(string $content): void {
 		$parts = preg_split('/(\s+)/Su', $content, 3, PREG_SPLIT_DELIM_CAPTURE);
-		
+
 		$this->parseType($parts);
 		$this->parseVariable($parts);
 		$this->setDescription(implode('', $parts));
 	}
-	
+
 	/**
 	 * Parses the type from the extracted parts
 	 * 
 	 * @param array $parts
-	 * @return array the remaining parts
 	 */
-	private function parseType(&$parts) {
+	private function parseType(array &$parts): void {
 		// if the first item that is encountered is not a variable; it is a type
 		if (isset($parts[0])
 				&& (strlen($parts[0]) > 0)
 				&& ($parts[0][0] !== '$')
 				&& substr($parts[0], 0, 4) !== '...$') {
-					$this->type = array_shift($parts);
+			$this->type = array_shift($parts);
 			array_shift($parts);
 		}
 	}
-	
+
 	/**
 	 * Parses the variable from the extracted parts
 	 *
 	 * @param array $parts
-	 * @return array the remaining parts
 	 */
-	private function parseVariable(&$parts) {
+	private function parseVariable(array &$parts): void {
 		// if the next item starts with a $ or ...$ it must be the variable name
 		if (isset($parts[0])
 				&& (strlen($parts[0]) > 0)
@@ -59,55 +64,59 @@ abstract class AbstractVarTypeTag extends AbstractTypeTag {
 			}
 		}
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		$type = !empty($this->type) ? $this->type . ' ' : '';
 		$var = !empty($this->variable)
-			? ($this->isVariadic ? '...' : '') . $this->variable . ' ' : ''; 
+			? ($this->isVariadic ? '...' : '') . $this->variable . ' ' : '';
+
 		return trim(sprintf('@%s %s%s%s', $this->tagName, $type, $var, $this->description));
 	}
-	
+
 	/**
 	 * Returnst the variable
 	 * 
 	 * @return string the variable name
 	 */
-	public function getVariable() {
+	public function getVariable(): string {
 		return $this->variable;
 	}
-	
+
 	/**
 	 * Sets the variable
 	 *
 	 * @param string $variable the new variable name
+	 *
 	 * @return $this        	
 	 */
-	public function setVariable($variable) {
+	public function setVariable(string $variable): self {
 		if ($variable[0] !== '$') {
 			$variable = '$' . $variable;
 		}
 		$this->variable = $variable;
+
 		return $this;
 	}
-	
+
 	/**
 	 * Returns if the variable is variadic
 	 * 
-	 * @return boolean if the variable is variadic
+	 * @return bool if the variable is variadic
 	 */
-	public function isVariadic() {
+	public function isVariadic(): bool {
 		return $this->isVariadic;
 	}
-	
+
 	/**
 	 * Sets whether the variable should be variadic
 	 * 
-	 * @param boolean $variadic
+	 * @param bool $variadic
+	 *
 	 * @return $this        	
 	 */
-	public function setVariadic($variadic) {
+	public function setVariadic(bool $variadic): self {
 		$this->isVariadic = $variadic;
+
 		return $this;
 	}
-	
 }

--- a/src/tags/AbstractVersionTag.php
+++ b/src/tags/AbstractVersionTag.php
@@ -1,17 +1,19 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
  * Represents tags which are in the format
+ *
  *   @tag [Version] [Description]
  */
 abstract class AbstractVersionTag extends AbstractDescriptionTag {
-	
+
 	/**
 	 * PCRE regular expression matching a version vector.
 	 * Assumes the "x" modifier.
 	 */
-	const REGEX_VECTOR = '(?:
+	const REGEX_VERSION = '(?:
         # Normal release vectors.
         \d\S*
         |
@@ -22,52 +24,54 @@ abstract class AbstractVersionTag extends AbstractDescriptionTag {
         # around the actual version vector.
         [^\s\:]+\:\s*\$[^\$]+\$
     )';
-	
-	protected $version;
-	
+
+	/** @var string */
+	protected $version = '';
+
 	/**
 	 * @see https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/phpDocumentor/Reflection/DocBlock/Tag/VersionTag.php Original Method: setContent()
 	 * @see \gossi\docblock\tags\AbstractTag::parse()
 	 */
-	protected function parse($content) {
+	protected function parse(string $content): void {
 		$matches = [];
 		if (preg_match(
-	            '/^
+				'/^
 	                # The version vector
-	                (' . self::REGEX_VECTOR . ')
+	                (' . self::REGEX_VERSION . ')
 	                \s*
 	                # The description
 	                (.+)?
 	            $/sux',
-	            $content,
-	            $matches)) {
-            $this->version = $matches[1];
-            $this->setDescription(isset($matches[2]) ? $matches[2] : '');
-        }
+				$content,
+				$matches)) {
+			$this->version = $matches[1];
+			$this->setDescription(isset($matches[2]) ? $matches[2] : '');
+		}
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		return trim(sprintf('@%s %s %s', $this->tagName, $this->version, $this->description));
 	}
-	
+
 	/**
 	 * Returns the version
 	 * 
 	 * @return string the version
 	 */
-	public function getVersion() {
+	public function getVersion(): string {
 		return $this->version;
 	}
-	
+
 	/**
 	 * Sets the version
 	 * 
 	 * @param string $version the new version 
+	 *
 	 * @return $this       	
 	 */
-	public function setVersion($version) {
+	public function setVersion(string $version): self {
 		$this->version = $version;
+
 		return $this;
-	}	
-	
+	}
 }

--- a/src/tags/AuthorTag.php
+++ b/src/tags/AuthorTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,29 +8,34 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/author.html
  */
 class AuthorTag extends AbstractTag {
-	
+
 	/**
 	 * PCRE regular expression matching any valid value for the name component.
 	 */
 	const REGEX_AUTHOR_NAME = '[^\<]*';
-	
+
 	/**
 	 * PCRE regular expression matching any valid value for the email component.
 	 */
 	const REGEX_AUTHOR_EMAIL = '[^\>]*';
-	
-	protected $name;
-	protected $email;
-	
-	public function __construct($content = '') {
+
+	/** @var string */
+	protected $name = '';
+
+	/** @var string */
+	protected $email = '';
+
+	public function __construct(string $content = '') {
 		parent::__construct('author', $content);
 	}
-	
+
 	/**
 	 * @see https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/phpDocumentor/Reflection/DocBlock/Tag/AuthorTag.php Original Method: setContent()
 	 * @see \gossi\docblock\tags\AbstractTag::parse()
+	 *
+	 * @param string $content
 	 */
-	protected function parse($content) {
+	protected function parse(string $content): void {
 		$matches = [];
 		if (preg_match('/^(' . self::REGEX_AUTHOR_NAME . ')(\<(' . self::REGEX_AUTHOR_EMAIL . ')\>)?$/u',
 				$content, $matches)) {
@@ -39,50 +45,54 @@ class AuthorTag extends AbstractTag {
 			}
 		}
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		$email = !empty($this->email) ? '<' . $this->email . '>' : '';
+
 		return trim(sprintf('@author %s %s', $this->name, $email));
 	}
-	
+
 	/**
 	 * Returns the authors name
 	 * 
 	 * @return string the authors name
 	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->name;
 	}
-	
+
 	/**
 	 * Sets the authors name
 	 *
 	 * @param string $name the new name
+	 *
 	 * @return $this     	
 	 */
-	public function setName($name) {
+	public function setName(string $name): self {
 		$this->name = $name;
+
 		return $this;
 	}
-	
+
 	/**
 	 * Returns the authors email
 	 * 
 	 * @return string the authors email
 	 */
-	public function getEmail() {
+	public function getEmail(): string {
 		return $this->email;
 	}
-	
+
 	/**
 	 * Sets the authors email
 	 * 
 	 * @param string $email the new email
+	 *
 	 * @return $this         	
 	 */
-	public function setEmail($email) {
+	public function setEmail(string $email): self {
 		$this->email = $email;
+
 		return $this;
 	}
-	
 }

--- a/src/tags/DeprecatedTag.php
+++ b/src/tags/DeprecatedTag.php
@@ -1,15 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
- * Represents the @deprecated tag.
+ * Represents the `@deprecated` tag.
  * 
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/deprecated.html
  */
 class DeprecatedTag extends AbstractVersionTag {
-
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('deprecated', $content);
 	}
-	
 }

--- a/src/tags/LicenseTag.php
+++ b/src/tags/LicenseTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,23 +8,25 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/license.html
  */
 class LicenseTag extends AbstractTag {
-	
-	private $url;
-	private $license;
-	
+
+	/** @var  string */
+	private $url = '';
+
+	/** @var string */
+	private $license = '';
+
 	/**
 	 * Creates a new tag
 	 * 
-	 * @param string $tagName the tag name
 	 * @param string $content the tags content
 	 */
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('license', $content);
 	}
-	
-	protected function parse($content) {
+
+	protected function parse(string $content): void {
 		$parts = preg_split('/\s+/Su', $content, 2);
-	
+
 		$urlCandidate = $parts[0];
 		if (preg_match(LinkTag::URL_REGEX, $urlCandidate)) {
 			$this->url = $urlCandidate;
@@ -32,49 +35,52 @@ class LicenseTag extends AbstractTag {
 			$this->license = $content;
 		}
 	}
-	
+
 	/**
 	 * Returns the url
 	 *
 	 * @return string the url
 	 */
-	public function getUrl() {
+	public function getUrl(): string {
 		return $this->url;
 	}
-	
+
 	/**
 	 * Sets the url
 	 *
 	 * @param string $url
+	 *
 	 * @return $this
 	 */
-	public function setUrl($url) {
+	public function setUrl(string $url): self {
 		$this->url = $url;
+
 		return $this;
 	}
-	
+
 	/**
 	 * Returns the license
 	 * 
 	 * @return string
 	 */
-	public function getLicense() {
+	public function getLicense(): string {
 		return $this->license;
 	}
-	
+
 	/**
 	 * Sets the license
 	 * 
 	 * @param string $license
+	 *
 	 * @return $this        	
 	 */
-	public function setLicense($license) {
+	public function setLicense(string $license): self {
 		$this->license = $license;
+
 		return $this;
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		return sprintf('@license %s', trim($this->url . ' ' . $this->license));
 	}
-	
 }

--- a/src/tags/LinkTag.php
+++ b/src/tags/LinkTag.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace gossi\docblock\tags;
 
@@ -9,23 +9,25 @@ namespace gossi\docblock\tags;
  */
 class LinkTag extends AbstractDescriptionTag {
 
-	private $url;
-	
-	public function __construct($content = '') {
+	/** @var string */
+	private $url = '';
+
+	public function __construct(string $content = '') {
 		parent::__construct('link', $content);
 	}
-	
+
 	/**
 	 * Url Regex by @diegoperini
 	 * 
 	 * @see https://mathiasbynens.be/demo/url-regex
+	 *
 	 * @var string
 	 */
 	const URL_REGEX = '_^(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:/[^\s]*)?$_iuS';
-	
-	protected function parse($content) {
+
+	protected function parse(string $content): void {
 		$parts = preg_split('/\s+/Su', $content, 2);
-		
+
 		$urlCandidate = $parts[0];
 		if (preg_match(self::URL_REGEX, $urlCandidate)) {
 			$this->url = $urlCandidate;
@@ -34,28 +36,30 @@ class LinkTag extends AbstractDescriptionTag {
 			$this->setDescription($content);
 		}
 	}
-	
+
 	/**
 	 * Returns the url
 	 * 
 	 * @return string the url
 	 */
-	public function getUrl() {
+	public function getUrl(): string {
 		return $this->url;
 	}
-	
+
 	/**
 	 * Sets the url
 	 * 
 	 * @param string $url
+	 *
 	 * @return $this
 	 */
-	public function setUrl($url) {
+	public function setUrl(string $url): self {
 		$this->url = $url;
+
 		return $this;
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		return trim(sprintf('@link %s', trim($this->url . ' ' . $this->description)));
 	}
 }

--- a/src/tags/MethodTag.php
+++ b/src/tags/MethodTag.php
@@ -1,13 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
+
 /**
- * Represents the @method tag.
+ * Represents the `@method` tag.
  * 
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/method.html
  */
 class MethodTag extends AbstractVarTypeTag {
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('method', $content);
 	}
-	
 }

--- a/src/tags/ParamTag.php
+++ b/src/tags/ParamTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/param.html
  */
 class ParamTag extends AbstractVarTypeTag {
-
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('param', $content);
 	}
-	
 }

--- a/src/tags/PropertyReadTag.php
+++ b/src/tags/PropertyReadTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/property-read.html
  */
 class PropertyReadTag extends AbstractVarTypeTag {
-
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('property-read', $content);
 	}
-	
 }

--- a/src/tags/PropertyTag.php
+++ b/src/tags/PropertyTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/property.html
  */
 class PropertyTag extends AbstractVarTypeTag {
-
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('property', $content);
 	}
-	
 }

--- a/src/tags/PropertyWriteTag.php
+++ b/src/tags/PropertyWriteTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/property-write.html
  */
 class PropertyWriteTag extends AbstractVarTypeTag {
-
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('property-write', $content);
 	}
-	
 }

--- a/src/tags/ReturnTag.php
+++ b/src/tags/ReturnTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/return.html
  */
 class ReturnTag extends AbstractTypeTag {
-	
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('return', $content);
 	}
-
 }

--- a/src/tags/SeeTag.php
+++ b/src/tags/SeeTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,41 +8,44 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/see.html
  */
 class SeeTag extends AbstractDescriptionTag {
-	
+
+	/** @var string */
 	protected $reference;
-	
-	public function __construct($content = '') {
+
+	public function __construct(string $content = '') {
 		parent::__construct('see', $content);
 	}
-	
-	protected function parse($content) {
+
+	protected function parse(string $content): void {
 		$parts = preg_split('/\s+/Su', $content, 2);
-		
+
 		$this->reference = $parts[0];
 		$this->setDescription(isset($parts[1]) ? $parts[1] : '');
 	}
-	
-	public function toString() {
-		return trim(sprintf('@see %s', trim($this->reference . ' ' .$this->description)));
+
+	public function toString(): string {
+		return trim(sprintf('@see %s', trim($this->reference . ' ' . $this->description)));
 	}
-	
+
 	/**
 	 * Returns the reference
 	 * 
 	 * @return string the reference
 	 */
-	public function getReference() {
+	public function getReference(): string {
 		return $this->reference;
 	}
-	
+
 	/**
 	 * Sets the reference
 	 *
-	 * @param string $reference a URL or FQSEN        	
+	 * @param string $reference a URL or FQSEN
+	 *
+	 * @return SeeTag
 	 */
-	public function setReference($reference) {
+	public function setReference(string $reference): self {
 		$this->reference = $reference;
+
 		return $this;
 	}
-	
 }

--- a/src/tags/SinceTag.php
+++ b/src/tags/SinceTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/since.html
  */
 class SinceTag extends AbstractVersionTag {
-	
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('since', $content);
 	}
-	
 }

--- a/src/tags/TagFactory.php
+++ b/src/tags/TagFactory.php
@@ -1,20 +1,21 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
  * Tag Factory
  */
 class TagFactory {
-	
+
 	/**
 	 * @var array An array with a tag as a key, and an FQCN as the handling class.
 	 */
-	private static $tagClassMap = array(
+	private static $tagClassMap = [
 			'author' => '\gossi\docblock\tags\AuthorTag',
 			'deprecated' => '\gossi\docblock\tags\DeprecatedTag',
 // 			'example' => '\gossi\docblock\tags\ExampleTag',
-// 			'link' => '\gossi\docblock\tags\LinkTag',
-// 			'method' => '\gossi\docblock\tags\MethodTag',
+			'link' => '\gossi\docblock\tags\LinkTag',
+			'method' => '\gossi\docblock\tags\MethodTag',
 			'param' => '\gossi\docblock\tags\ParamTag',
 			'property-read' => '\gossi\docblock\tags\PropertyReadTag',
 			'property' => '\gossi\docblock\tags\PropertyTag',
@@ -29,22 +30,26 @@ class TagFactory {
 // 			'uses' => '\gossi\docblock\tags\UsesTag',
 			'var' => '\gossi\docblock\tags\VarTag',
 			'version' => '\gossi\docblock\tags\VersionTag'
-	);
-	
+	];
+
 	/**
 	 * Creates a new tag instance on the given name
 	 * 
 	 * @param string $tagName
 	 * @param string $content
+	 *
 	 * @return AbstractTag
+	 *
+	 * @psalm-suppress LessSpecificReturnStatement
+	 * @psalm-suppress MoreSpecificReturnType
 	 */
-	public static function create($tagName, $content = '') {
+	public static function create(string $tagName, string $content = ''): AbstractTag {
 		if (isset(self::$tagClassMap[$tagName])) {
 			$class = self::$tagClassMap[$tagName];
+
 			return new $class($content);
 		} else {
 			return new UnknownTag($tagName, $content);
 		}
 	}
-	
 }

--- a/src/tags/ThrowsTag.php
+++ b/src/tags/ThrowsTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/throws.html
  */
 class ThrowsTag extends AbstractTypeTag {
-	
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('throws', $content);
 	}
-	
 }

--- a/src/tags/TypeTag.php
+++ b/src/tags/TypeTag.php
@@ -1,13 +1,12 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
  * Represents the @type tag.
  */
 class TypeTag extends AbstractVarTypeTag {
-	
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('type', $content);
 	}
-
 }

--- a/src/tags/UnknownTag.php
+++ b/src/tags/UnknownTag.php
@@ -1,26 +1,27 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
  * Represents an unknown tag.
  */
 class UnknownTag extends AbstractDescriptionTag {
-	
+
 	/**
 	 * Creates a new tag
 	 * 
 	 * @param string $tagName the tag name
 	 * @param string $content the tags content
 	 */
-	public function __construct($tagName, $content = '') {
+	public function __construct(string $tagName, string $content = '') {
 		parent::__construct($tagName, $content);
 	}
-	
-	protected function parse($content) {
+
+	protected function parse(string $content): void {
 		$this->setDescription($content);
 	}
-	
-	public function toString() {
+
+	public function toString(): string {
 		return sprintf('@%s %s', $this->tagName, $this->description);
 	}
 }

--- a/src/tags/VarTag.php
+++ b/src/tags/VarTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +8,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/var.html
  */
 class VarTag extends AbstractVarTypeTag {
-	
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('var', $content);
 	}
-
 }

--- a/src/tags/VersionTag.php
+++ b/src/tags/VersionTag.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 namespace gossi\docblock\tags;
 
 /**
@@ -7,9 +7,7 @@ namespace gossi\docblock\tags;
  * @see http://www.phpdoc.org/docs/latest/references/phpdoc/tags/version.html
  */
 class VersionTag extends AbstractVersionTag {
-	
-	public function __construct($content = '') {
+	public function __construct(string $content = '') {
 		parent::__construct('version', $content);
 	}
-
 }

--- a/tests/DocblockTest.php
+++ b/tests/DocblockTest.php
@@ -1,56 +1,58 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests;
 
 use gossi\docblock\Docblock;
-use gossi\docblock\tags\ThrowsTag;
-use gossi\docblock\tests\fixtures\MyDocBlock;
 use gossi\docblock\tags\AuthorTag;
-use gossi\docblock\tags\SeeTag;
-use gossi\docblock\tags\SinceTag;
+use gossi\docblock\tags\ParamTag;
 use gossi\docblock\tags\PropertyTag;
 use gossi\docblock\tags\ReturnTag;
-use gossi\docblock\tags\ParamTag;
+use gossi\docblock\tags\SeeTag;
+use gossi\docblock\tags\SinceTag;
+use gossi\docblock\tags\ThrowsTag;
 use gossi\docblock\tags\UnknownTag;
+use gossi\docblock\tests\fixtures\MyDocBlock;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class DocblockTest extends \PHPUnit_Framework_TestCase {
-
-	public function testShortDescription() {
+class DocblockTest extends TestCase {
+	public function testShortDescription(): void {
 		$desc = 'Hello World';
 		$docblock = new Docblock();
 
 		$docblock->setShortDescription($desc);
-		
+
 		$this->assertEquals($desc, $docblock->getShortDescription());
 	}
-	
-	public function testLongDescription() {
+
+	public function testLongDescription(): void {
 		$desc = 'Hello World';
 		$docblock = new Docblock();
-	
+
 		$docblock->setLongDescription($desc);
-	
+
 		$this->assertEquals($desc, $docblock->getLongDescription());
 	}
-	
-	public function testSimpleReadWrite() {
+
+	public function testSimpleReadWrite(): void {
 		$expected = '/**
  * Short Description.
  *
  * Long Description.
  */';
 		$docblock = new Docblock($expected);
-		
+
 		$this->assertEquals('Short Description.', $docblock->getShortDescription());
 		$this->assertEquals('Long Description.', $docblock->getLongDescription());
 		$this->assertEquals($expected, $docblock->toString());
 	}
-	
-	public function testSingleLine() {
+
+	public function testSingleLine(): void {
 		$docblock = new Docblock('/** Single Line Doc */');
 		$this->assertEquals('Single Line Doc', $docblock->getShortDescription());
 	}
-	
-	public function testTags() {
+
+	public function testTags(): void {
 		$expected = '/**
  * @see https://github.com/gossi/docblock
  * @author gossi
@@ -58,42 +60,40 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
  * @since 28.5.2014
  */';
 		$docblock = new Docblock($expected);
-		
+
 		$tags = $docblock->getTags();
 		$this->assertEquals(4, $tags->size());
 		$this->assertTrue($docblock->hasTag('see'));
 		$this->assertTrue($docblock->hasTag('author'));
 		$this->assertTrue($docblock->hasTag('since'));
 		$this->assertFalse($docblock->hasTag('license'));
-		
+
 		$authors = $docblock->getTags('author');
 		$this->assertEquals(2, $authors->size());
-		
+
 		$this->assertEquals($expected, $docblock->toString());
 		$this->assertSame($docblock, $docblock->appendTag(ThrowsTag::create()));
-		
+
 		$tags = $docblock->getTags();
 		$this->assertEquals(5, $tags->size());
-		
+
 		$this->assertTrue($docblock->hasTag('author'));
 		$this->assertFalse($docblock->hasTag('moooh'));
 	}
-	
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function testInvalidTags() {
+
+	public function testInvalidTags(): void {
+		$this->expectException(InvalidArgumentException::class);
+
 		new MyDocBlock('');
 	}
-	
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function testInvalidDocblockParameter() {
+
+	public function testInvalidDocblockParameter(): void {
+		$this->expectException(InvalidArgumentException::class);
+
 		new Docblock(new \stdClass());
 	}
-	
-	public function testMultilLongLineDescription() {
+
+	public function testMultilLongLineDescription(): void {
 		$expected = '/**
  * Short Description.
  *
@@ -106,10 +106,10 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
  *     linee
  */';
 		$docblock = new Docblock($expected);
- 		$this->assertEquals($expected, $docblock->toString());
+		$this->assertEquals($expected, $docblock->toString());
 	}
-	
-	public function testFromReflection() {
+
+	public function testFromReflection(): void {
 		$expected = '/**
  * Short Description.
  *
@@ -117,13 +117,13 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
  */';
 		$reflection = new \ReflectionClass('\\gossi\\docblock\\tests\\fixtures\\ReflectionTestClass');
 		$docblock = Docblock::create($reflection);
-		
+
 		$this->assertEquals($expected, '' . $docblock);
 	}
-	
-	public function testTagSorting() {
+
+	public function testTagSorting(): void {
 		$doc = new Docblock();
-		
+
 		$doc->appendTag(new AuthorTag());
 		$doc->appendTag(new SeeTag());
 		$doc->appendTag(new ThrowsTag());
@@ -133,36 +133,34 @@ class DocblockTest extends \PHPUnit_Framework_TestCase {
 		$doc->appendTag(new ParamTag());
 		$doc->appendTag(new PropertyTag());
 		$doc->appendTag(new ReturnTag());
-		
+
 		$actual = [];
 		$expected = ['wurst', 'see', 'author', 'property', 'since', 'param', 'param', 'throws', 'return'];
 		$sorted = $doc->getSortedTags();
 		foreach ($sorted as $tag) {
 			$actual[] = $tag->getTagName();
 		}
-		
+
 		$this->assertEquals($expected, $actual);
 	}
-	
-	public function testEmpty() {
+
+	public function testEmpty(): void {
 		$doc = new Docblock();
 		$this->assertTrue($doc->isEmpty());
-		
+
 		$doc->setLongDescription('bla');
 		$this->assertFalse($doc->isEmpty());
-		
-		$doc->setLongDescription(null);
+
+		$doc->setLongDescription();
 		$this->assertTrue($doc->isEmpty());
-		
+
 		$doc->setShortDescription('bla');
 		$this->assertFalse($doc->isEmpty());
-		
-		$doc->setShortDescription(null);
+
+		$doc->setShortDescription();
 		$this->assertTrue($doc->isEmpty());
 
 		$doc->appendTag(new SeeTag());
 		$this->assertFalse($doc->isEmpty());
-		
 	}
-	
 }

--- a/tests/TagNameComparatorTest.php
+++ b/tests/TagNameComparatorTest.php
@@ -1,16 +1,16 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests;
 
 use gossi\docblock\TagNameComparator;
 use phootwork\collection\ArrayList;
+use PHPUnit\Framework\TestCase;
 
-class TagNameComparatorTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testComparison() {
+class TagNameComparatorTest extends TestCase {
+	public function testComparison(): void {
 		$list = new ArrayList(['author', 'since', 'see', 'param', 'author']);
 		$list->sort(new TagNameComparator());
-		
+
 		$this->assertEquals(['see', 'author', 'author', 'since', 'param'], $list->toArray());
 	}
-	
 }

--- a/tests/fixtures/MyDocBlock.php
+++ b/tests/fixtures/MyDocBlock.php
@@ -1,11 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 namespace gossi\docblock\tests\fixtures;
 
 use gossi\docblock\Docblock;
 
 class MyDocBlock extends Docblock {
-	
-	protected function splitDocblock($comment) {
-		return array('', '', 'Invalid tag block');
+	protected function splitDocblock($comment): array {
+		return ['', '', 'Invalid tag block'];
 	}
 }

--- a/tests/fixtures/ReflectionTestClass.php
+++ b/tests/fixtures/ReflectionTestClass.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\fixtures;
 
 /**

--- a/tests/tags/AuthorTagTest.php
+++ b/tests/tags/AuthorTagTest.php
@@ -1,37 +1,38 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\AuthorTag;
+use PHPUnit\Framework\TestCase;
 
-class AuthorTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class AuthorTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$author = new AuthorTag('gossi <hans@wurst.de>');
-		
+
 		$this->assertEquals('gossi', $author->getName());
 		$this->assertEquals('hans@wurst.de', $author->getEmail());
 		$this->assertEquals('@author gossi <hans@wurst.de>', $author->toString());
-		
+
 		$author = new AuthorTag('lil-g');
-		
+
 		$this->assertEquals('lil-g', $author->getName());
 		$this->assertEmpty($author->getEmail());
 		$this->assertEquals('@author lil-g', $author->toString());
 	}
-	
-	public function testName() {
+
+	public function testName(): void {
 		$name = 'gossi';
 		$author = new AuthorTag();
-		
+
 		$this->assertSame($author, $author->setName($name));
 		$this->assertEquals($name, $author->getName());
 	}
-	
-	public function testEmail() {
+
+	public function testEmail(): void {
 		$email = 'hans@wurst.de';
 		$author = new AuthorTag();
-		
-		$this->assertSame($author, $author->setEmail($email));		
+
+		$this->assertSame($author, $author->setEmail($email));
 		$this->assertEquals($email, $author->getEmail());
 	}
 }

--- a/tests/tags/DeprecatedTagTest.php
+++ b/tests/tags/DeprecatedTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\DeprecatedTag;
+use PHPUnit\Framework\TestCase;
 
-class DeprecatedTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class DeprecatedTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$deprecated = new DeprecatedTag();
 		$this->assertEquals('@deprecated', $deprecated->toString());
 	}
-	
 }

--- a/tests/tags/LicenseTagTest.php
+++ b/tests/tags/LicenseTagTest.php
@@ -1,36 +1,37 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\LicenseTag;
+use PHPUnit\Framework\TestCase;
 
-class LicenseTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class LicenseTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$license = new LicenseTag('MIT');
-		
+
 		$this->assertEquals('MIT', $license->getLicense());
 		$this->assertEquals('@license MIT', $license->toString());
-		
+
 		$license = new LicenseTag('http://opensource.org/licenses/MIT MIT');
-		
+
 		$this->assertEquals('MIT', $license->getLicense());
 		$this->assertEquals('http://opensource.org/licenses/MIT', $license->getUrl());
 		$this->assertEquals('@license http://opensource.org/licenses/MIT MIT', $license->toString());
 	}
-	
-	public function testLicense() {
+
+	public function testLicense(): void {
 		$name = 'gossi';
 		$license = new LicenseTag();
-		
+
 		$this->assertSame($license, $license->setLicense($name));
 		$this->assertEquals($name, $license->getLicense());
 	}
-	
-	public function testUrl() {
+
+	public function testUrl(): void {
 		$url = 'http://opensource.org/licenses/MIT';
 		$license = new LicenseTag();
-		
-		$this->assertSame($license, $license->setUrl($url));		
+
+		$this->assertSame($license, $license->setUrl($url));
 		$this->assertEquals($url, $license->getUrl());
 	}
 }

--- a/tests/tags/LinkTagTest.php
+++ b/tests/tags/LinkTagTest.php
@@ -1,39 +1,39 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\LinkTag;
+use PHPUnit\Framework\TestCase;
 
-class LinkTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class LinkTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$link = new LinkTag('http://example.com');
 		$this->assertEquals('http://example.com', $link->getUrl());
 		$this->assertEquals('@link http://example.com', $link->toString());
-		
-		$link = new LinkTag('http://example.com desc');		
+
+		$link = new LinkTag('http://example.com desc');
 		$this->assertEquals('http://example.com', $link->getUrl());
 		$this->assertEquals('desc', $link->getDescription());
 		$this->assertEquals('@link http://example.com desc', $link->toString());
-		
+
 		$link = new LinkTag('http://.example.com desc');
-		$this->assertNull($link->getUrl());
+		$this->assertEmpty($link->getUrl());
 		$this->assertEquals('http://.example.com desc', $link->getDescription());
 	}
 
-	public function testUrl() {
+	public function testUrl(): void {
 		$url = 'http://example.com';
 		$link = new LinkTag();
-		
+
 		$this->assertSame($link, $link->setUrl($url));
 		$this->assertEquals($url, $link->getUrl());
 	}
 
-	public function testDescription() {
+	public function testDescription(): void {
 		$desc = 'desc';
 		$link = new LinkTag();
-		
-		$this->assertSame($link, $link->setDescription($desc));		
+
+		$this->assertSame($link, $link->setDescription($desc));
 		$this->assertEquals($desc, $link->getDescription());
 	}
-
 }

--- a/tests/tags/MethodTagTest.php
+++ b/tests/tags/MethodTagTest.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace gossi\docblock\tests\tags;
+
+use gossi\docblock\tags\MethodTag;
+use PHPUnit\Framework\TestCase;
+
+class MethodTagTest extends TestCase {
+	public function testReadWrite(): void {
+		$method = new MethodTag('string myMethod()');
+		$this->assertEquals('@method string myMethod()', $method->toString());
+	}
+}

--- a/tests/tags/ParamTagTest.php
+++ b/tests/tags/ParamTagTest.php
@@ -1,45 +1,46 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\ParamTag;
+use PHPUnit\Framework\TestCase;
 
-class ParamTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class ParamTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$param = new ParamTag('string $a the string');
-		
+
 		$this->assertEquals('string', $param->getType());
 		$this->assertEquals('$a', $param->getVariable());
 		$this->assertEquals('the string', $param->getDescription());
 		$this->assertFalse($param->isVariadic());
 		$this->assertEquals('@param string $a the string', $param->toString());
-		
+
 		$param = new ParamTag('string ...$a');
-		
+
 		$this->assertEmpty($param->getDescription());
 		$this->assertTrue($param->isVariadic());
 		$this->assertEquals('@param string ...$a', $param->toString());
 	}
-	
-	public function testType() {
+
+	public function testType(): void {
 		$type = 'int';
 		$param = new ParamTag();
-		
+
 		$this->assertSame($param, $param->setType($type));
 		$this->assertEquals($type, $param->getType());
 	}
-	
-	public function testVariable() {
+
+	public function testVariable(): void {
 		$variable = '$v';
 		$param = new ParamTag();
-		
+
 		$this->assertSame($param, $param->setVariable($variable));
 		$this->assertEquals($variable, $param->getVariable());
 	}
-	
-	public function testVariadic() {
+
+	public function testVariadic(): void {
 		$param = new ParamTag();
-		
+
 		$this->assertSame($param, $param->setVariadic(true));
 		$this->assertTrue($param->isVariadic());
 	}

--- a/tests/tags/PropertyReadTagTest.php
+++ b/tests/tags/PropertyReadTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\PropertyReadTag;
+use PHPUnit\Framework\TestCase;
 
-class PropertyReadTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class PropertyReadTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$prop = new PropertyReadTag('string $var');
 		$this->assertEquals('@property-read string $var', $prop->toString());
 	}
-	
 }

--- a/tests/tags/PropertyTagTest.php
+++ b/tests/tags/PropertyTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\PropertyTag;
+use PHPUnit\Framework\TestCase;
 
-class PropertyTagTest extends \PHPUnit_Framework_TestCase {
-	
+class PropertyTagTest extends TestCase {
 	public function testReadWrite() {
 		$prop = new PropertyTag('string $var');
 		$this->assertEquals('@property string $var', $prop->toString());
 	}
-	
 }

--- a/tests/tags/PropertyWriteTagTest.php
+++ b/tests/tags/PropertyWriteTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\PropertyWriteTag;
+use PHPUnit\Framework\TestCase;
 
-class PropertyWriteTagTest extends \PHPUnit_Framework_TestCase {
-	
+class PropertyWriteTagTest extends TestCase {
 	public function testReadWrite() {
 		$prop = new PropertyWriteTag('string $var');
 		$this->assertEquals('@property-write string $var', $prop->toString());
 	}
-	
 }

--- a/tests/tags/ReturnTagTest.php
+++ b/tests/tags/ReturnTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\ReturnTag;
+use PHPUnit\Framework\TestCase;
 
-class ReturnTagTest extends \PHPUnit_Framework_TestCase {
-	
+class ReturnTagTest extends TestCase {
 	public function testReadWrite() {
 		$return = new ReturnTag('Foo bar');
 		$this->assertEquals('@return Foo bar', $return->toString());
 	}
-	
 }

--- a/tests/tags/SeeTagTest.php
+++ b/tests/tags/SeeTagTest.php
@@ -1,19 +1,19 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\SeeTag;
+use PHPUnit\Framework\TestCase;
 
-class SeeTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class SeeTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$see = new SeeTag('Dest::nation() 0815');
 		$this->assertEquals('@see Dest::nation() 0815', $see->toString());
 	}
-	
-	public function testReference() {
+
+	public function testReference(): void {
 		$see = new SeeTag();
 		$this->assertSame($see, $see->setReference('hier-lang'));
 		$this->assertEquals('hier-lang', $see->getReference());
 	}
-	
 }

--- a/tests/tags/SinceTagTest.php
+++ b/tests/tags/SinceTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\SinceTag;
+use PHPUnit\Framework\TestCase;
 
-class SinceTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class SinceTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$since = new SinceTag('1.0 baz');
 		$this->assertEquals('@since 1.0 baz', $since->toString());
 	}
-	
 }

--- a/tests/tags/TagFactoryTest.php
+++ b/tests/tags/TagFactoryTest.php
@@ -1,22 +1,22 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
-use gossi\docblock\tags\TagFactory;
 use gossi\docblock\tags\AuthorTag;
+use gossi\docblock\tags\TagFactory;
 use gossi\docblock\tags\UnknownTag;
+use PHPUnit\Framework\TestCase;
 
-class TagFactoryTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testFactory() {
+class TagFactoryTest extends TestCase {
+	public function testFactory(): void {
 		$factory = new TagFactory();
-		
+
 		$author = $factory->create('author', 'lil-g');
 		$this->assertTrue($author instanceof AuthorTag);
 		$this->assertEquals('lil-g', $author->getName());
-		
+
 		$unknown = $factory->create('wurst');
 		$this->assertTrue($unknown instanceof UnknownTag);
 		$this->assertEquals('wurst', $unknown->getTagName());
 	}
-	
 }

--- a/tests/tags/ThrowsTest.php
+++ b/tests/tags/ThrowsTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\ThrowsTag;
+use PHPUnit\Framework\TestCase;
 
-class ThrowsTagTest extends \PHPUnit_Framework_TestCase {
-	
+class ThrowsTagTest extends TestCase {
 	public function testReadWrite() {
 		$ex = new ThrowsTag('\Exception oups');
 		$this->assertEquals('@throws \Exception oups', $ex->toString());
 	}
-	
 }

--- a/tests/tags/TypeTagTest.php
+++ b/tests/tags/TypeTagTest.php
@@ -1,13 +1,13 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\TypeTag;
+use PHPUnit\Framework\TestCase;
 
-class TypeTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class TypeTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$type = new TypeTag('Foo ...$bar');
 		$this->assertEquals('@type Foo ...$bar', $type->toString());
 	}
-	
 }

--- a/tests/tags/UnknownTagTest.php
+++ b/tests/tags/UnknownTagTest.php
@@ -1,19 +1,19 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\UnknownTag;
+use PHPUnit\Framework\TestCase;
 
-class UnknownTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class UnknownTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$unknown = new UnknownTag('my-tag', 'desscription');
-		
+
 		$this->assertEquals('@my-tag desscription', $unknown->toString());
 		$this->assertEquals('my-tag', $unknown->getTagName());
-		
+
 		$this->assertEquals($unknown->toString(), '' . $unknown);
-		
+
 		$this->assertTrue(UnknownTag::create() instanceof UnknownTag);
 	}
-	
 }

--- a/tests/tags/VarTagTest.php
+++ b/tests/tags/VarTagTest.php
@@ -1,17 +1,18 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
-use gossi\docblock\tags\VarTag;
 use gossi\docblock\Docblock;
+use gossi\docblock\tags\VarTag;
+use PHPUnit\Framework\TestCase;
 
-class VarTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class VarTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$var = new VarTag('Foo ...$bar');
 		$this->assertEquals('@var Foo ...$bar', $var->toString());
 	}
-	
-	public function testDocblock() {
+
+	public function testDocblock(): void {
 		$expected = '/**
  * @var mixed $foo bar
  */';
@@ -22,7 +23,7 @@ class VarTagTest extends \PHPUnit_Framework_TestCase {
 			->setDescription('bar')
 		;
 		$docblock->appendTag($var);
-		
+
 		$this->assertEquals($expected, $docblock->toString());
 	}
 }

--- a/tests/tags/VersionTagTest.php
+++ b/tests/tags/VersionTagTest.php
@@ -1,11 +1,12 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace gossi\docblock\tests\tags;
 
 use gossi\docblock\tags\VersionTag;
+use PHPUnit\Framework\TestCase;
 
-class VersionTagTest extends \PHPUnit_Framework_TestCase {
-	
-	public function testReadWrite() {
+class VersionTagTest extends TestCase {
+	public function testReadWrite(): void {
 		$version = new VersionTag('1.3.3.7 jupjup');
 		$this->assertEquals('@version 1.3.3.7 jupjup', $version->toString());
 		$this->assertEquals('jupjup', $version->getDescription());
@@ -13,5 +14,4 @@ class VersionTagTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame($version, $version->setVersion('3.14'));
 		$this->assertEquals('3.14', $version->getVersion());
 	}
-	
 }


### PR DESCRIPTION
Move forward the best docblock manipulation library around here. 
This work is based on the ideas behind [phootwork](https://github.com/phootwork/phootwork) version 2.0:

  - PHP 7.2+ with strict types
  - Bump dependencies version
  - Introduce Psalm static analysis tool
  - Use [phootwork/php-cs-fixer-config](https://github.com/phootwork/php-cs-fixer-config) to well define the coding standard
  - Remove Sami from dependencies: it's legacy and causes many conflicts. Refactor the `api` composer script to download the phar archive.

Note: in my mind, this refactor is the first step to bump [gossi/php-code-generator](https://github.com/gossi/php-code-generator) dependencies, which is impossible to install, at the moment, for projects using i.e. symfony 4+ components.