### PR TITLE
Fix `getVariable()` method

### DIFF
--- a/src/tags/AbstractVarTypeTag.php
+++ b/src/tags/AbstractVarTypeTag.php
@@ -106,7 +106,7 @@ abstract class AbstractVarTypeTag extends AbstractTypeTag {
 	public function getVariable(): string {
 		$variable = new Text($this->variable);
 
-		return $variable->slice(1)->toString();
+		return $variable->isEmpty() ? '' : $variable->slice(1)->toString();
 	}
 
 	/**

--- a/tests/tags/ParamTagTest.php
+++ b/tests/tags/ParamTagTest.php
@@ -44,4 +44,10 @@ class ParamTagTest extends TestCase {
 		$this->assertSame($param, $param->setVariadic(true));
 		$this->assertTrue($param->isVariadic());
 	}
+
+	public function testGetVariableNameOnEmptyTag(): void {
+		$param = new ParamTag();
+
+		$this->assertEquals('', $param->getVariable());
+	}
 }


### PR DESCRIPTION
Before this commit, `AbstractVarTypeTag::getVariable()` called on an empty tag, causes an exception.
With this commit it returns an empty string.