### PR TITLE
Fix coverage report workflow

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 7.4
           extensions: mbstring, dom, json, libxml, xml, xmlwriter
           coverage: pcov
       - name: Install dependencies


### PR DESCRIPTION
Set php version to 7.4 in coverage report workflow for an issue in Scrutinizer `ocular.phar`.
See https://github.com/scrutinizer-ci/ocular/issues/54