### PR TITLE
Bump phootwork dependencies

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -26,5 +26,7 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageCommand: "composer coverage:clover"
-      - name: Upload Scrutinizer coverage
-        run: vendor/bin/ocular code-coverage:upload --format=php-clover clover.xml
+      - name: Scrutinizer coverage report
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover clover.xml"

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,13 @@
 	},
 	"require" : {
 		"php" : ">=8.0",
-		"phootwork/collection" : "^2.1",
-		"phootwork/lang": "^2.1"
+		"phootwork/collection" : "^3.0",
+		"phootwork/lang": "^3.0"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "^9.0",
 		"phootwork/php-cs-fixer-config": "^0.3",
-		"psalm/phar": "^4.3",
-		"scrutinizer/ocular": "^1.8"
+		"psalm/phar": "^4.3"
 	},
 	"scripts": {
 		"analytics": "vendor/bin/psalm.phar",


### PR DESCRIPTION
-  Bump phootwork dependencies to version 3.0
-  Remove `scrutinizer/ocular` from dev deps: I found [this docker-ized action](https://github.com/marketplace/actions/action-scrutinizer) perfectly fitting our needs :smile:  