### PR TITLE
Fix tags parser

### DIFF
--- a/src/Docblock.php
+++ b/src/Docblock.php
@@ -184,7 +184,7 @@ class Docblock implements \Stringable {
 			foreach (explode("\n", $tags) as $line) {
 				if ($this->isTagLine($line) || count($result) == 0) {
 					$result[] = $line;
-				} else {
+				} elseif ($line !== '') {
 					$result[count($result) - 1] .= "\n" . $line;
 				}
 			}

--- a/tests/DocblockTest.php
+++ b/tests/DocblockTest.php
@@ -201,4 +201,20 @@ class DocblockTest extends TestCase {
 		$this->assertTrue($docblock->hasTag('see'));
 		$this->assertFalse($docblock->hasTag('since'));
 	}
+
+	public function testDocblockWithBlankLines(): void {
+		$text = '/**
+ * @param string $foo makes a fow
+ *
+ * @return bool true on success and false if it fails
+ */';
+		$docblock = new Docblock($text);
+		$tags = $docblock->getTags();
+
+		$this->assertEquals(2, $tags->size());
+		$this->assertInstanceOf(ParamTag::class, $tags->get(0));
+		$this->assertEquals('makes a fow', $tags->get(0)->getDescription());
+		$this->assertInstanceOf(ReturnTag::class, $tags->get(1));
+		$this->assertEquals('true on success and false if it fails', $tags->get(1)->getDescription());
+	}
 }


### PR DESCRIPTION
Fix tag parser when there's a blank line between tags.
I added a test which fails without this commit.